### PR TITLE
Fix problems with editor when changing tabs

### DIFF
--- a/frontend/app/(app)/code/[id]/page.tsx
+++ b/frontend/app/(app)/code/[id]/page.tsx
@@ -63,14 +63,6 @@ const CodeEditor = dynamic(() => import("@/components/editor"), {
   loading: () => <Loading />,
 })
 
-function getReactDefinitionFile() {
-  const reactDefinitionFile = fs.readFileSync(
-    "node_modules/@types/react/index.d.ts",
-    "utf8"
-  )
-  return reactDefinitionFile
-}
-
 export default async function CodePage({ params }: { params: { id: string } }) {
   const user = await currentUser()
   const sandboxId = params.id
@@ -94,8 +86,6 @@ export default async function CodePage({ params }: { params: { id: string } }) {
     return notFound()
   }
 
-  const reactDefinitionFile = getReactDefinitionFile()
-
   return (
     <div className="overflow-hidden overscroll-none w-screen flex flex-col h-screen bg-background">
       <Room id={sandboxId}>
@@ -104,7 +94,6 @@ export default async function CodePage({ params }: { params: { id: string } }) {
           <CodeEditor
             userData={userData}
             sandboxData={sandboxData}
-            reactDefinitionFile={reactDefinitionFile}
           />
         </div>
       </Room>

--- a/frontend/components/editor/index.tsx
+++ b/frontend/components/editor/index.tsx
@@ -397,7 +397,7 @@ export default function CodeEditor({
         providerData.binding = undefined;
       }
     };
-  }, [editorRef, room, activeFileContent, activeFileId, tabs]);
+  }, [editorRef, room, activeFileContent]);
 
     // Added this effect to clean up when the component unmounts
     useEffect(() => {

--- a/frontend/components/editor/index.tsx
+++ b/frontend/components/editor/index.tsx
@@ -35,11 +35,9 @@ import { ImperativePanelHandle } from "react-resizable-panels"
 export default function CodeEditor({
   userData,
   sandboxData,
-  reactDefinitionFile,
 }: {
   userData: User
   sandboxData: Sandbox
-  reactDefinitionFile: string
 }) {
   const socketRef = useRef<Socket | null>(null);
 

--- a/frontend/components/editor/index.tsx
+++ b/frontend/components/editor/index.tsx
@@ -397,7 +397,7 @@ export default function CodeEditor({
         providerData.binding = undefined;
       }
     };
-  }, [editorRef, room, activeFileContent]);
+  }, [room, activeFileContent]);
 
     // Added this effect to clean up when the component unmounts
     useEffect(() => {


### PR DESCRIPTION
This PR fixes two problems:
* Liveblocks creates redundant providers when changing tabs, causing some edits to be garbled
* There was a problem with the order of updates in a useEffect, causing the wrong text to show up in the wrong tab (on Windows only)

https://www.youtube.com/watch?v=Hyx7bjtasf4