### PR TITLE
Feat/editor fix n UI updates

### DIFF
--- a/frontend/components/dashboard/newProject.tsx
+++ b/frontend/components/dashboard/newProject.tsx
@@ -36,43 +36,7 @@ import { createSandbox } from "@/lib/actions"
 import { useRouter } from "next/navigation"
 import { Loader2 } from "lucide-react"
 import { Button } from "../ui/button"
-
-const data: {
-  id: string
-  name: string
-  icon: string
-  description: string
-  disabled: boolean
-}[] = [
-  {
-    id: "reactjs",
-    name: "React",
-    icon: "/project-icons/react.svg",
-    description: "A JavaScript library for building user interfaces",
-    disabled: false,
-  },
-  {
-    id: "vanillajs",
-    name: "HTML/JS",
-    icon: "/project-icons/more.svg",
-    description: "More coming soon, feel free to contribute on GitHub",
-    disabled: false,
-  },
-  {
-    id: "nextjs",
-    name: "NextJS",
-    icon: "/project-icons/node.svg",
-    description: "A JavaScript runtime built on the V8 JavaScript engine",
-    disabled: false,
-  },
-  {
-    id: "streamlit",
-    name: "Streamlit",
-    icon: "/project-icons/python.svg",
-    description: "A JavaScript runtime built on the V8 JavaScript engine",
-    disabled: false,
-  },
-]
+import { projectTemplates } from "@/lib/data"
 
 const formSchema = z.object({
   name: z
@@ -129,7 +93,7 @@ export default function NewProjectModal({
           <DialogTitle>Create A Sandbox</DialogTitle>
         </DialogHeader>
         <div className="grid grid-cols-2 w-full gap-2 mt-2">
-          {data.map((item) => (
+          {projectTemplates.map((item) => (
             <button
               disabled={item.disabled || loading}
               key={item.id}

--- a/frontend/components/dashboard/newProject.tsx
+++ b/frontend/components/dashboard/newProject.tsx
@@ -71,7 +71,7 @@ const data: {
     icon: "/project-icons/python.svg",
     description: "A JavaScript runtime built on the V8 JavaScript engine",
     disabled: false,
-  }
+  },
 ]
 
 const formSchema = z.object({
@@ -124,7 +124,7 @@ export default function NewProjectModal({
         if (!loading) setOpen(open)
       }}
     >
-      <DialogContent>
+      <DialogContent className="max-h-[95vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create A Sandbox</DialogTitle>
         </DialogHeader>

--- a/frontend/components/dashboard/projectCard/index.tsx
+++ b/frontend/components/dashboard/projectCard/index.tsx
@@ -8,6 +8,7 @@ import { Clock, Globe, Lock } from "lucide-react"
 import { Sandbox } from "@/lib/types"
 import { Card } from "@/components/ui/card"
 import { useRouter } from "next/navigation"
+import { projectTemplates } from "@/lib/data"
 
 export default function ProjectCard({
   children,
@@ -43,7 +44,9 @@ export default function ProjectCard({
       setDate(`${Math.floor(diffInMinutes / 1440)}d ago`)
     }
   }, [sandbox])
-
+  const projectIcon =
+    projectTemplates.find((p) => p.id === sandbox.type)?.icon ??
+    "/project-icons/node.svg"
   return (
     <Card
       tabIndex={0}
@@ -65,16 +68,7 @@ export default function ProjectCard({
       </AnimatePresence>
 
       <div className="space-x-2 flex items-center justify-start w-full z-10">
-        <Image
-          alt=""
-          src={
-            sandbox.type === "react"
-              ? "/project-icons/react.svg"
-              : "/project-icons/node.svg"
-          }
-          width={20}
-          height={20}
-        />
+        <Image alt="" src={projectIcon} width={20} height={20} />
         <div className="font-medium static whitespace-nowrap w-full text-ellipsis overflow-hidden">
           {sandbox.name}
         </div>

--- a/frontend/components/editor/sidebar/folder.tsx
+++ b/frontend/components/editor/sidebar/folder.tsx
@@ -1,18 +1,20 @@
-"use client";
+"use client"
 
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-import { getIconForFolder, getIconForOpenFolder } from "vscode-icons-js";
-import { TFile, TFolder, TTab } from "@/lib/types";
-import SidebarFile from "./file";
+import Image from "next/image"
+import { useEffect, useRef, useState } from "react"
+import { getIconForFolder, getIconForOpenFolder } from "vscode-icons-js"
+import { TFile, TFolder, TTab } from "@/lib/types"
+import SidebarFile from "./file"
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
-} from "@/components/ui/context-menu";
-import { Loader2, Pencil, Trash2 } from "lucide-react";
-import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+} from "@/components/ui/context-menu"
+import { ChevronRight, Loader2, Pencil, Trash2 } from "lucide-react"
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter"
+import { cn } from "@/lib/utils"
+import { motion, AnimatePresence } from "framer-motion"
 
 // Note: Renaming has not been implemented in the backend yet, so UI relating to renaming is commented out
 
@@ -25,27 +27,27 @@ export default function SidebarFolder({
   movingId,
   deletingFolderId,
 }: {
-  data: TFolder;
-  selectFile: (file: TTab) => void;
+  data: TFolder
+  selectFile: (file: TTab) => void
   handleRename: (
     id: string,
     newName: string,
     oldName: string,
     type: "file" | "folder"
-  ) => boolean;
-  handleDeleteFile: (file: TFile) => void;
-  handleDeleteFolder: (folder: TFolder) => void;
-  movingId: string;
-  deletingFolderId: string;
+  ) => boolean
+  handleDeleteFile: (file: TFile) => void
+  handleDeleteFolder: (folder: TFolder) => void
+  movingId: string
+  deletingFolderId: string
 }) {
-  const ref = useRef(null); // drop target
-  const [isDraggedOver, setIsDraggedOver] = useState(false);
+  const ref = useRef(null) // drop target
+  const [isDraggedOver, setIsDraggedOver] = useState(false)
 
   const isDeleting =
-    deletingFolderId.length > 0 && data.id.startsWith(deletingFolderId);
+    deletingFolderId.length > 0 && data.id.startsWith(deletingFolderId)
 
   useEffect(() => {
-    const el = ref.current;
+    const el = ref.current
 
     if (el)
       return dropTargetForElements({
@@ -67,17 +69,17 @@ export default function SidebarFolder({
 
         // no dropping while awaiting move
         canDrop: () => {
-          return !movingId;
+          return !movingId
         },
-      });
-  }, []);
+      })
+  }, [])
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false)
   const folder = isOpen
     ? getIconForOpenFolder(data.name)
-    : getIconForFolder(data.name);
+    : getIconForFolder(data.name)
 
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null)
   // const [editing, setEditing] = useState(false);
 
   // useEffect(() => {
@@ -96,6 +98,12 @@ export default function SidebarFolder({
           isDraggedOver ? "bg-secondary/50 rounded-t-sm" : "rounded-sm"
         } w-full flex items-center h-7 px-1 transition-colors hover:bg-secondary cursor-pointer`}
       >
+        <ChevronRight
+          className={cn(
+            "min-w-3 min-h-3 mr-1 ml-auto transition-all duration-300",
+            isOpen ? "transform rotate-90" : ""
+          )}
+        />
         <Image
           src={`/icons/${folder}`}
           alt="Folder icon"
@@ -149,48 +157,65 @@ export default function SidebarFolder({
         <ContextMenuItem
           disabled={isDeleting}
           onClick={() => {
-            handleDeleteFolder(data);
+            handleDeleteFolder(data)
           }}
         >
           <Trash2 className="w-4 h-4 mr-2" />
           Delete
         </ContextMenuItem>
       </ContextMenuContent>
-      {isOpen ? (
-        <div
-          className={`flex w-full items-stretch ${
-            isDraggedOver ? "rounded-b-sm bg-secondary/50" : ""
-          }`}
-        >
-          <div className="w-[1px] bg-border mx-2 h-full"></div>
-          <div className="flex flex-col grow">
-            {data.children.map((child) =>
-              child.type === "file" ? (
-                <SidebarFile
-                  key={child.id}
-                  data={child}
-                  selectFile={selectFile}
-                  handleRename={handleRename}
-                  handleDeleteFile={handleDeleteFile}
-                  movingId={movingId}
-                  deletingFolderId={deletingFolderId}
-                />
-              ) : (
-                <SidebarFolder
-                  key={child.id}
-                  data={child}
-                  selectFile={selectFile}
-                  handleRename={handleRename}
-                  handleDeleteFile={handleDeleteFile}
-                  handleDeleteFolder={handleDeleteFolder}
-                  movingId={movingId}
-                  deletingFolderId={deletingFolderId}
-                />
-              )
-            )}
-          </div>
-        </div>
-      ) : null}
+      <AnimatePresence>
+        {isOpen ? (
+          <motion.div
+            className="overflow-y-hidden"
+            initial={{
+              height: 0,
+              opacity: 0,
+            }}
+            animate={{
+              height: "auto",
+              opacity: 1,
+            }}
+            exit={{
+              height: 0,
+              opacity: 0,
+            }}
+          >
+            <div
+              className={cn(
+                isDraggedOver ? "rounded-b-sm bg-secondary/50" : ""
+              )}
+            >
+              <div className="flex flex-col grow ml-2 pl-2 border-l border-border">
+                {data.children.map((child) =>
+                  child.type === "file" ? (
+                    <SidebarFile
+                      key={child.id}
+                      data={child}
+                      selectFile={selectFile}
+                      handleRename={handleRename}
+                      handleDeleteFile={handleDeleteFile}
+                      movingId={movingId}
+                      deletingFolderId={deletingFolderId}
+                    />
+                  ) : (
+                    <SidebarFolder
+                      key={child.id}
+                      data={child}
+                      selectFile={selectFile}
+                      handleRename={handleRename}
+                      handleDeleteFile={handleDeleteFile}
+                      handleDeleteFolder={handleDeleteFolder}
+                      movingId={movingId}
+                      deletingFolderId={deletingFolderId}
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
     </ContextMenu>
-  );
+  )
 }

--- a/frontend/lib/data/index.ts
+++ b/frontend/lib/data/index.ts
@@ -1,0 +1,36 @@
+export const projectTemplates: {
+  id: string
+  name: string
+  icon: string
+  description: string
+  disabled: boolean
+}[] = [
+  {
+    id: "reactjs",
+    name: "React",
+    icon: "/project-icons/react.svg",
+    description: "A JavaScript library for building user interfaces",
+    disabled: false,
+  },
+  {
+    id: "vanillajs",
+    name: "HTML/JS",
+    icon: "/project-icons/more.svg",
+    description: "More coming soon, feel free to contribute on GitHub",
+    disabled: false,
+  },
+  {
+    id: "nextjs",
+    name: "NextJS",
+    icon: "/project-icons/node.svg",
+    description: "A JavaScript runtime built on the V8 JavaScript engine",
+    disabled: false,
+  },
+  {
+    id: "streamlit",
+    name: "Streamlit",
+    icon: "/project-icons/python.svg",
+    description: "A JavaScript runtime built on the V8 JavaScript engine",
+    disabled: false,
+  },
+]

--- a/frontend/lib/tsconfig.ts
+++ b/frontend/lib/tsconfig.ts
@@ -1,0 +1,99 @@
+import * as monaco from "monaco-editor"
+
+export function parseTSConfigToMonacoOptions(
+  tsconfig: any
+): monaco.languages.typescript.CompilerOptions {
+  const compilerOptions: monaco.languages.typescript.CompilerOptions = {}
+
+  // Map tsconfig options to Monaco CompilerOptions
+  if (tsconfig.strict) compilerOptions.strict = tsconfig.strict
+  if (tsconfig.target) compilerOptions.target = mapScriptTarget(tsconfig.target)
+  if (tsconfig.module) compilerOptions.module = mapModule(tsconfig.module)
+  if (tsconfig.lib) compilerOptions.lib = tsconfig.lib
+  if (tsconfig.allowJs) compilerOptions.allowJs = tsconfig.allowJs
+  if (tsconfig.checkJs) compilerOptions.checkJs = tsconfig.checkJs
+  if (tsconfig.jsx) compilerOptions.jsx = mapJSX(tsconfig.jsx)
+  if (tsconfig.declaration) compilerOptions.declaration = tsconfig.declaration
+  if (tsconfig.declarationMap)
+    compilerOptions.declarationMap = tsconfig.declarationMap
+  if (tsconfig.sourceMap) compilerOptions.sourceMap = tsconfig.sourceMap
+  if (tsconfig.outFile) compilerOptions.outFile = tsconfig.outFile
+  if (tsconfig.outDir) compilerOptions.outDir = tsconfig.outDir
+  if (tsconfig.removeComments)
+    compilerOptions.removeComments = tsconfig.removeComments
+  if (tsconfig.noEmit) compilerOptions.noEmit = tsconfig.noEmit
+  if (tsconfig.noEmitOnError)
+    compilerOptions.noEmitOnError = tsconfig.noEmitOnError
+
+  return compilerOptions
+}
+
+function mapScriptTarget(
+  target: string
+): monaco.languages.typescript.ScriptTarget {
+  const targetMap: { [key: string]: monaco.languages.typescript.ScriptTarget } =
+    {
+      es3: monaco.languages.typescript.ScriptTarget.ES3,
+      es5: monaco.languages.typescript.ScriptTarget.ES5,
+      es6: monaco.languages.typescript.ScriptTarget.ES2015,
+      es2015: monaco.languages.typescript.ScriptTarget.ES2015,
+      es2016: monaco.languages.typescript.ScriptTarget.ES2016,
+      es2017: monaco.languages.typescript.ScriptTarget.ES2017,
+      es2018: monaco.languages.typescript.ScriptTarget.ES2018,
+      es2019: monaco.languages.typescript.ScriptTarget.ES2019,
+      es2020: monaco.languages.typescript.ScriptTarget.ES2020,
+      esnext: monaco.languages.typescript.ScriptTarget.ESNext,
+    }
+  if (typeof target !== "string") {
+    return monaco.languages.typescript.ScriptTarget.Latest
+  }
+  return (
+    targetMap[target?.toLowerCase()] ||
+    monaco.languages.typescript.ScriptTarget.Latest
+  )
+}
+
+function mapModule(module: string): monaco.languages.typescript.ModuleKind {
+  const moduleMap: { [key: string]: monaco.languages.typescript.ModuleKind } = {
+    none: monaco.languages.typescript.ModuleKind.None,
+    commonjs: monaco.languages.typescript.ModuleKind.CommonJS,
+    amd: monaco.languages.typescript.ModuleKind.AMD,
+    umd: monaco.languages.typescript.ModuleKind.UMD,
+    system: monaco.languages.typescript.ModuleKind.System,
+    es6: monaco.languages.typescript.ModuleKind.ES2015,
+    es2015: monaco.languages.typescript.ModuleKind.ES2015,
+    esnext: monaco.languages.typescript.ModuleKind.ESNext,
+  }
+  if (typeof module !== "string") {
+    return monaco.languages.typescript.ModuleKind.ESNext
+  }
+  return (
+    moduleMap[module.toLowerCase()] ||
+    monaco.languages.typescript.ModuleKind.ESNext
+  )
+}
+
+function mapJSX(jsx: string): monaco.languages.typescript.JsxEmit {
+  const jsxMap: { [key: string]: monaco.languages.typescript.JsxEmit } = {
+    preserve: monaco.languages.typescript.JsxEmit.Preserve,
+    react: monaco.languages.typescript.JsxEmit.React,
+    "react-native": monaco.languages.typescript.JsxEmit.ReactNative,
+  }
+  return jsxMap[jsx.toLowerCase()] || monaco.languages.typescript.JsxEmit.React
+}
+
+// Example usage:
+const tsconfigJSON = {
+  compilerOptions: {
+    strict: true,
+    target: "ES2020",
+    module: "ESNext",
+    lib: ["DOM", "ES2020"],
+    jsx: "react",
+    sourceMap: true,
+    outDir: "./dist",
+  },
+}
+
+const monacoOptions = parseTSConfigToMonacoOptions(tsconfigJSON.compilerOptions)
+console.log(monacoOptions)

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -75,3 +75,26 @@ export function debounce<T extends (...args: any[]) => void>(
     timeout = setTimeout(() => func(...args), wait)
   } as T
 }
+
+// Deep merge utility function
+export const deepMerge = (target: any, source: any) => {
+  const output = { ...target }
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!(key in target)) {
+          Object.assign(output, { [key]: source[key] })
+        } else {
+          output[key] = deepMerge(target[key], source[key])
+        }
+      } else {
+        Object.assign(output, { [key]: source[key] })
+      }
+    })
+  }
+  return output
+}
+
+const isObject = (item: any) => {
+  return item && typeof item === "object" && !Array.isArray(item)
+}


### PR DESCRIPTION
1. remove the editor's red squiggly lines by dynamically loading the project's tsconfig file and adding nice defaults

![Screenshot 2024-09-24 125641](https://github.com/user-attachments/assets/c72ac15e-de43-4e75-8d0e-85620b939533)
2. improve folder structure UI with animations

| **Before** | **After** |
| :------------------- | :---------- |
| ![fs-before](https://github.com/user-attachments/assets/1c6366c5-4f05-40bb-baf9-e792315954f6) | ![fs-after](https://github.com/user-attachments/assets/172d9db8-f200-49d6-b3d4-0dadaea338e7) |
3.  new project modal scrolls when it overflows, instead of clipping content(older behavior)

![newproject-overflow](https://github.com/user-attachments/assets/a5a92338-bacb-4e1a-a226-e9743d3e0599)
4. Projects on the dashboard now have the appropriate icons

![image](https://github.com/user-attachments/assets/53820d5d-9cad-4471-b9df-c1e40b26554b)

