### PR TITLE
Fix/root file moves

### DIFF
--- a/backend/server/src/FileManager.ts
+++ b/backend/server/src/FileManager.ts
@@ -1,8 +1,8 @@
 import {
-    Sandbox as Container,
-    FilesystemEvent,
-    FilesystemEventType,
-    WatchHandle,
+  Sandbox as Container,
+  FilesystemEvent,
+  FilesystemEventType,
+  WatchHandle,
 } from "e2b"
 import path from "path"
 import { MAX_BODY_SIZE } from "./ratelimit"
@@ -172,7 +172,10 @@ export class FileManager {
   }
 
   // Move a file to a different folder
-  async moveFile(fileId: string, folderId: string): Promise<(TFolder | TFile)[]> {
+  async moveFile(
+    fileId: string,
+    folderId: string
+  ): Promise<(TFolder | TFile)[]> {
     // Normalize the folder ID for root directory
     const normalizedFolderId = folderId.includes("projects/") ? "/" : folderId
     

--- a/backend/server/src/FileManager.ts
+++ b/backend/server/src/FileManager.ts
@@ -1,8 +1,8 @@
 import {
-  Sandbox as Container,
-  FilesystemEvent,
-  FilesystemEventType,
-  WatchHandle,
+    Sandbox as Container,
+    FilesystemEvent,
+    FilesystemEventType,
+    WatchHandle,
 } from "e2b"
 import path from "path"
 import { MAX_BODY_SIZE } from "./ratelimit"
@@ -172,11 +172,14 @@ export class FileManager {
   }
 
   // Move a file to a different folder
-  async moveFile(
-    fileId: string,
-    folderId: string
-  ): Promise<(TFolder | TFile)[]> {
-    const newFileId = path.posix.join(folderId, path.posix.basename(fileId))
+  async moveFile(fileId: string, folderId: string): Promise<(TFolder | TFile)[]> {
+    // Normalize the folder ID for root directory
+    const normalizedFolderId = folderId.includes("projects/") ? "/" : folderId
+    
+    // Create the new file path
+    const newFileId = normalizedFolderId === "/" 
+      ? path.posix.basename(fileId)  // For root, just use filename
+      : path.posix.join(normalizedFolderId, path.posix.basename(fileId))
 
     await this.moveFileInContainer(fileId, newFileId)
     await this.fixPermissions()


### PR DESCRIPTION
# Fix: Moving Files from Subfolder to Root

## Problem
When moving files from a subfolder to root using drag and drop, files were incorrectly being moved to `projects/{projectId}` instead of the root directory.

## Solution
Added path normalization in `FileManager.moveFile()` to properly handle root directory moves:
- Detect root directory moves by checking for "projects/" in folder ID
- Use basename for root moves instead of full path join
- Maintain existing behavior for non-root moves
