### PR TITLE
Fix/root file moves

### DIFF
--- a/backend/server/src/FileManager.ts
+++ b/backend/server/src/FileManager.ts
@@ -172,7 +172,10 @@ export class FileManager {
   }
 
   // Move a file to a different folder
-  async moveFile(fileId: string, folderId: string): Promise<(TFolder | TFile)[]> {
+  async moveFile(
+    fileId: string, 
+    folderId: string
+  ): Promise<(TFolder | TFile)[]> {
     const newFileId = path.posix.join(folderId, path.posix.basename(fileId))
     await this.moveFileInContainer(fileId, newFileId)
     await this.fixPermissions()

--- a/backend/server/src/FileManager.ts
+++ b/backend/server/src/FileManager.ts
@@ -172,21 +172,10 @@ export class FileManager {
   }
 
   // Move a file to a different folder
-  async moveFile(
-    fileId: string,
-    folderId: string
-  ): Promise<(TFolder | TFile)[]> {
-    // Normalize the folder ID for root directory
-    const normalizedFolderId = folderId.includes("projects/") ? "/" : folderId
-    
-    // Create the new file path
-    const newFileId = normalizedFolderId === "/" 
-      ? path.posix.basename(fileId)  // For root, just use filename
-      : path.posix.join(normalizedFolderId, path.posix.basename(fileId))
-
+  async moveFile(fileId: string, folderId: string): Promise<(TFolder | TFile)[]> {
+    const newFileId = path.posix.join(folderId, path.posix.basename(fileId))
     await this.moveFileInContainer(fileId, newFileId)
     await this.fixPermissions()
-
     return await this.getFileTree()
   }
 

--- a/backend/server/src/FileManager.ts
+++ b/backend/server/src/FileManager.ts
@@ -240,7 +240,7 @@ export class FileManager {
 
   // Delete a folder
   async deleteFolder(folderId: string): Promise<(TFolder | TFile)[]> {
-    this.container.files.remove(path.posix.join(this.dirName, folderId))
+    await this.container.files.remove(path.posix.join(this.dirName, folderId))
     return await this.getFileTree()
   }
 

--- a/frontend/components/editor/sidebar/index.tsx
+++ b/frontend/components/editor/sidebar/index.tsx
@@ -60,7 +60,7 @@ export default function Sidebar({
     if (el) {
       return dropTargetForElements({
         element: el,
-        getData: () => ({ id: `projects/${sandboxData.id}` }),
+        getData: () => ({ id: "/" }),
         canDrop: ({ source }) => {
           const file = files.find((child) => child.id === source.data.id)
           return !file


### PR DESCRIPTION
# Fix File Drag & Drop to Root Directory

## Problem  
When moving files from a subfolder to the root directory using drag and drop, files were incorrectly being moved to `projects/{projectId}` instead of `/`.  

## Solution  
Updated the root drop target ID in the sidebar from `projects/${sandboxId}` to `/` to align with the filesystem structure.  

## Changes 

```typescript
// frontend/components/editor/sidebar/index.tsx

useEffect(() => {
  const el = ref.current;

  if (el) {
    return dropTargetForElements({
      element: el,
      getData: () => ({ id: "/" }), // Changed from `projects/${sandboxData.id}`
      canDrop: ({ source }) => {
        const file = files.find((child) => child.id === source.data.id);
        return !file;
      },
    });
  }
}, [files]);
