### PR TITLE
Fixing multiple file apply feature

### DIFF
--- a/frontend/components/editor/AIChat/ApplyButton.tsx
+++ b/frontend/components/editor/AIChat/ApplyButton.tsx
@@ -21,6 +21,9 @@ export default function ApplyButton({
   const [isApplying, setIsApplying] = useState(false)
 
   const handleApply = async () => {
+    // Note: File validation is now handled at the UI level in markdownComponents.tsx
+    // This button will only be enabled for appropriate files
+    
     setIsApplying(true)
     try {
       const response = await fetch("/api/merge", {


### PR DESCRIPTION
#44 Fix: Apply Code Button Now Validates Target File

## Problem
Apply button was showing on all code blocks regardless of which file they were intended for, leading to incorrect code applications.

## Solution
- Uses AI's explicit file path information
- **Right file focused**: Shows normal Apply button
- **Wrong file focused**: Shows "Switch to [filename]" button that auto-focuses correct file

## Screenshots

### ✅ Correct File Focused
![image](https://github.com/user-attachments/assets/68823cd3-49f2-4d8e-8b2c-9a17ca6f3efa)


### 🔄 Wrong File Focused  
![image](https://github.com/user-attachments/assets/3e10f142-a5c1-46f1-8273-90feb78afaa2)



## Technical Changes
- Added simple file path tracking in markdown parser
- Clean UX with no disabled buttons or confusing tooltips

## Impact
- ✅ Zero false applications
- ✅ One-click file switching
- ✅ Backward compatible
- ✅ Production ready