### PR TITLE
Fix/project name spaces 

### DIFF
--- a/backend/server/src/services/FileManager.ts
+++ b/backend/server/src/services/FileManager.ts
@@ -36,7 +36,7 @@ export class FileManager {
     // Run the command to retrieve paths
     // Ignore node_modules until we make this faster
     const result = await this.container.commands.run(
-      `cd /home/user/project && find * \\( -path 'node_modules' -prune \\) -o \\( -type d -exec echo {}/ \\; -o -type f -exec echo {} \\; \\)`
+      `cd "${this.dirName}" && find * \\( -path 'node_modules' -prune \\) -o \\( -type d -exec echo {}/ \\; -o -type f -exec echo {} \\; \\)`
     )
 
     // Process the stdout into an array of paths
@@ -212,7 +212,7 @@ export class FileManager {
 
     // Create an archive of the project directory
     await this.container.commands.run(
-      `cd ${this.dirName} && tar --exclude="node_modules" --exclude="venv" -czvf ${tempTarPath} .`,
+      `cd "${this.dirName}" && tar --exclude="node_modules" --exclude="venv" -czvf "${tempTarPath}" .`,
       {
         timeoutMs: 5000,
       }
@@ -220,11 +220,11 @@ export class FileManager {
 
     // Read the archive contents in base64 format
     const base64Result = await this.container.commands.run(
-      `cat ${tempTarPath} | base64 -w 0`
+      `cat "${tempTarPath}" | base64 -w 0`
     )
 
     // Delete the archive
-    await this.container.commands.run(`rm ${tempTarPath}`)
+    await this.container.commands.run(`rm "${tempTarPath}"`)
 
     // Return the base64 encoded tar.gz content
     return base64Result.stdout.trim()

--- a/backend/server/src/utils/pathUtils.ts
+++ b/backend/server/src/utils/pathUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Safely quotes a path for shell command usage, handling spaces and special characters
+ * @param path The path to quote
+ * @returns The safely quoted path
+ */
+export function quotePath(path: string): string {
+  // If path already contains quotes, strip them first to avoid double-quoting
+  const cleanPath = path.replace(/^["']|["']$/g, '')
+  
+  // Quote the path to handle spaces and special characters
+  return `"${cleanPath.replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Safely escapes a path component for use in file operations
+ * @param pathComponent A single path component (file or folder name)
+ * @returns The escaped path component
+ */
+export function escapePathComponent(pathComponent: string): string {
+  // Replace any potentially problematic characters
+  return pathComponent.replace(/[^a-zA-Z0-9._\- ]/g, '_')
+} 

--- a/frontend/components/dashboard/newProject.tsx
+++ b/frontend/components/dashboard/newProject.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
 } from "@/components/ui/dialog"
 import { zodResolver } from "@hookform/resolvers/zod"
 import Image from "next/image"
@@ -13,21 +13,21 @@ import { useForm } from "react-hook-form"
 import { z } from "zod"
 
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select"
 import { createSandbox } from "@/lib/actions"
 import { projectTemplates } from "@/lib/data"
@@ -43,11 +43,20 @@ import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures"
 const formSchema = z.object({
   name: z
     .string()
-    .min(1)
-    .max(16)
+    .min(1, "Project name is required")
+    .max(16, "Project name must be 16 characters or less")
+    .transform((val) => val.trim())
     .refine(
-      (value) => /^[a-zA-Z0-9_]+$/.test(value),
-      "Name must be alphanumeric and can contain underscores"
+      (value) => value.length > 0,
+      "Project name cannot be empty or only spaces"
+    )
+    .refine(
+      (value) => /^[a-zA-Z0-9_ ]+$/.test(value),
+      "Project name can only contain letters, numbers, underscores, and spaces"
+    )
+    .refine(
+      (value) => !/  /.test(value),
+      "Project name cannot contain multiple consecutive spaces"
     ),
   visibility: z.enum(["public", "private"]),
 })
@@ -218,7 +227,7 @@ export default function NewProjectModal({
                   <FormControl>
                     <Input
                       disabled={loading}
-                      placeholder="My Project"
+                      placeholder="My Awesome Project"
                       {...field}
                     />
                   </FormControl>

--- a/frontend/components/editor/AIChat/lib/chatUtils.ts
+++ b/frontend/components/editor/AIChat/lib/chatUtils.ts
@@ -247,7 +247,8 @@ export const looksLikeCode = (text: string): boolean => {
 // Add this new function after looksLikeCode function
 export const isFilePath = (text: string): boolean => {
   // Match patterns like next/styles/SignIn.module.css or path/to/file.ext (new file)
+  // Updated to allow spaces in file and folder names
   const pattern =
-    /^(?:[a-zA-Z0-9_.-]+\/)*[a-zA-Z0-9_.-]+\.[a-zA-Z0-9]+(\s+\(new file\))?$/
+    /^(?:[a-zA-Z0-9_.\- ]+\/)*[a-zA-Z0-9_.\- ]+\.[a-zA-Z0-9]+(\s+\(new file\))?$/
   return pattern.test(text)
 }

--- a/frontend/components/editor/AIChat/lib/markdownComponents.tsx
+++ b/frontend/components/editor/AIChat/lib/markdownComponents.tsx
@@ -26,8 +26,10 @@ export const createMarkdownComponents = (
   mergeDecorationsCollection?: monaco.editor.IEditorDecorationsCollection,
   setMergeDecorationsCollection?: (collection: undefined) => void
 ): Components => {
-  // State to track the intended file for the next code block
-  let intendedFile: string | null = null
+  // Create a simple component-scoped tracker that won't cause re-renders
+  // Using a closure variable instead of window storage for better type safety
+  let fileIntentions = new Map<number, string>()
+  let paragraphIndex = 0
 
   return {
   code: ({
@@ -58,6 +60,12 @@ export const createMarkdownComponents = (
       }
     }
 
+    // Get the intended file for this code block (latest one before this code block)
+    const currentCodeBlockIndex = paragraphIndex++
+    const intendedFile = Array.from(fileIntentions.entries())
+      .filter(([index]: [number, string]) => index < currentCodeBlockIndex)
+      .pop()?.[1] || null
+
     return match ? (
       <div className="relative border border-input rounded-md mt-8 my-2 translate-y-[-1rem]">
         <div className="absolute top-0 left-0 px-2 py-1 text-xs font-semibold text-foreground/70 rounded-tl">
@@ -70,10 +78,11 @@ export const createMarkdownComponents = (
             {!mergeDecorationsCollection ? (
               (() => {
                 if (intendedFile) {
-                  const intendedFileName = intendedFile.split("/").pop()?.toLowerCase() || ""
-                  const currentFileName = activeFileName.toLowerCase()
+                  const intendedFileName = intendedFile.split("/").pop()?.trim() || ""
+                  const intendedFileNameLower = intendedFileName.toLowerCase()
+                  const currentFileName = activeFileName.toLowerCase().trim()
                   
-                  if (intendedFileName === currentFileName) {
+                  if (intendedFileNameLower === currentFileName) {
                     // Correct file - show normal apply
                     return (
                       <ApplyButton
@@ -228,18 +237,21 @@ export const createMarkdownComponents = (
   // Render markdown elements
   p: ({ node, children, ...props }) => {
     const content = stringifyContent(children)
+    const currentParagraphIndex = paragraphIndex++
 
     if (isFilePath(content)) {
       const isNewFile = content.endsWith("(new file)")
-      const filePath = (
-        isNewFile ? content.replace(" (new file)", "") : content
-      )
-        .split("/")
-        .filter((part, index) => index !== 0)
+      const cleanContent = isNewFile ? content.replace(" (new file)", "") : content
+      
+      // Handle path processing - remove project name (first part) but preserve spaces in file names
+      const pathParts = cleanContent.split("/")
+      // Filter out the first part (project name) and any empty parts
+      const filePath = pathParts
+        .filter((part, index) => index !== 0 && part.trim().length > 0)
         .join("/")
 
       // Set the intended file for the next code blocks
-      intendedFile = filePath
+      fileIntentions.set(currentParagraphIndex, filePath)
 
       const handleFileClick = () => {
         if (isNewFile) {
@@ -263,15 +275,29 @@ export const createMarkdownComponents = (
             })
         } else {
           // First check if the file exists in the current tabs
+          const fileName = filePath.split("/").pop() || ""
+          
           const existingTab = tabs.find(
-            (t) => t.id === filePath || t.name === filePath.split("/").pop()
+            (t) => {
+              // More robust matching that handles various path formats
+              const normalizedTId = t.id.replace(/^\/+/, "").toLowerCase()
+              const normalizedFilePath = filePath.replace(/^\/+/, "").toLowerCase()
+              const tFileName = t.name.split("/").pop()?.toLowerCase() || ""
+              const fileNameLower = fileName.toLowerCase()
+              
+              return normalizedTId === normalizedFilePath || 
+                     tFileName === fileNameLower || 
+                     normalizedTId.endsWith(fileNameLower) ||
+                     t.name === fileName
+            }
           )
+          
           if (existingTab) {
             selectFile(existingTab)
           } else {
             const tab: TTab = {
               id: filePath,
-              name: filePath.split("/").pop() || "",
+              name: fileName,
               saved: true,
               type: "file",
             }

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -38,6 +38,7 @@ export function validateName(
   return { status: true, message: "" }
 }
 
+
 export function debounce<T extends (...args: any[]) => void>(
   func: T,
   wait: number

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -29,7 +29,6 @@ export function validateName(
   if (
     newName.includes("/") ||
     newName.includes("\\") ||
-    newName.includes(" ") ||
     (type === "file" && !newName.includes(".")) ||
     (type === "folder" && newName.includes("."))
   ) {
@@ -38,6 +37,18 @@ export function validateName(
   return { status: true, message: "" }
 }
 
+/**
+ * Safely quotes a path for shell command usage, handling spaces and special characters
+ * @param path The path to quote
+ * @returns The safely quoted path
+ */
+export function quotePath(path: string): string {
+  // If path already contains quotes, strip them first to avoid double-quoting
+  const cleanPath = path.replace(/^["']|["']$/g, '')
+  
+  // Quote the path to handle spaces and special characters
+  return `"${cleanPath.replace(/"/g, '\\"')}"`
+}
 
 export function debounce<T extends (...args: any[]) => void>(
   func: T,

--- a/frontend/server/routes/file.ts
+++ b/frontend/server/routes/file.ts
@@ -63,6 +63,9 @@ export const fileRouter = createRouter()
     ),
     async (c) => {
       const { fileId, projectId } = c.req.valid("query")
+      
+      // Decode URL-encoded file ID to handle spaces and special characters
+      const decodedFileId = decodeURIComponent(fileId)
 
       // Initialize project
       const project = new Project(projectId)
@@ -73,10 +76,10 @@ export const fileRouter = createRouter()
           throw new Error("File manager not available")
         }
 
-        const file = await project.fileManager.getFile(fileId)
+        const file = await project.fileManager.getFile(decodedFileId)
         return c.json(file)
       } catch (error) {
-        console.error(`Error reading file ${fileId}:`, error)
+        console.error(`Error reading file ${decodedFileId}:`, error)
         const errorMessage =
           error instanceof Error ? error.message : "Failed to read file"
         return c.json({ error: errorMessage }, 500)
@@ -129,6 +132,9 @@ export const fileRouter = createRouter()
     ),
     async (c) => {
       const { fileId, content, projectId } = c.req.valid("json")
+      
+      // Decode URL-encoded file ID to handle spaces and special characters
+      const decodedFileId = decodeURIComponent(fileId)
 
       // Initialize project
       const project = new Project(projectId)
@@ -143,7 +149,7 @@ export const fileRouter = createRouter()
           throw new Error("File manager not available")
         }
 
-        const result = await project.fileManager.saveFile(fileId, content)
+        const result = await project.fileManager.saveFile(decodedFileId, content)
         return c.json(
           {
             success: true,
@@ -292,6 +298,9 @@ export const fileRouter = createRouter()
     ),
     async (c) => {
       const { fileId, projectId } = c.req.valid("query")
+      
+      // Decode URL-encoded file ID to handle spaces and special characters
+      const decodedFileId = decodeURIComponent(fileId)
 
       const project = new Project(projectId)
       await project.initialize()
@@ -301,7 +310,7 @@ export const fileRouter = createRouter()
         // const user = c.get("user") as User
         // await deleteFileRL.consume(user.id, 1)
 
-        const result = await project.fileManager?.deleteFile(fileId)
+        const result = await project.fileManager?.deleteFile(decodedFileId)
         return c.json(
           {
             success: true,
@@ -369,12 +378,16 @@ export const fileRouter = createRouter()
     ),
     async (c) => {
       const { fileId, folderId, projectId } = c.req.valid("json")
+      
+      // Decode URL-encoded file IDs to handle spaces and special characters
+      const decodedFileId = decodeURIComponent(fileId)
+      const decodedFolderId = decodeURIComponent(folderId)
 
       const project = new Project(projectId)
       await project.initialize()
 
       try {
-        const result = await project.fileManager?.moveFile(fileId, folderId)
+        const result = await project.fileManager?.moveFile(decodedFileId, decodedFolderId)
         return c.json(
           {
             success: true,
@@ -442,12 +455,15 @@ export const fileRouter = createRouter()
     ),
     async (c) => {
       const { fileId, newName, projectId } = c.req.valid("json")
+      
+      // Decode URL-encoded file ID to handle spaces and special characters
+      const decodedFileId = decodeURIComponent(fileId)
 
       const project = new Project(projectId)
       await project.initialize()
 
       try {
-        await project.fileManager?.renameFile(fileId, newName)
+        await project.fileManager?.renameFile(decodedFileId, newName)
         return c.json(
           {
             success: true,


### PR DESCRIPTION
# Fix Project Names with Spaces

## Problem
Previously it wasnt possible to name a project with spaces when i added that another bug showed up, project names containing spaces were causing file path handling issues in the AI chat interface, resulting in 500 errors when accessing files due to improper URL encoding handling.

## Changes
- Enhanced file intention tracking in markdown components to properly handle spaces in file paths
- Added case-insensitive file matching for more robust file path handling
- Improved debug logging for better issue tracking and verification
- Updated file path handling to properly manage URL-encoded paths (spaces and special characters)

## Testing
- Verified file intention tracking works correctly with spaces in project names
- Confirmed proper handling of file paths containing spaces (e.g., "test me/style.css")
- Tested case-insensitive file matching functionality

## Impact
This fix ensures that projects with spaces in their names work correctly in the AI chat interface, improving overall system reliability and user experience.

Fixes #57 