### PR TITLE
docs: update .env.example and README.md with AWS Bedrock configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,11 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
 # Optional: As an alternative to Anthropic, you can use AWS Bedrock
-AWS_ACCESS_KEY_ID=  
-AWS_SECRET_ACCESS_KEY=  
-AWS_REGION=  
-AWS_ARN=  
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+AWS_MODEL_ID=qwen.qwen3-32b-v1:0
+# AWS_MODEL_ID=qwen.qwen3-coder-30b-a3b-v1:0  
 
 # Optional: Dokku credentials for deployments
 DOKKU_HOST=

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ OPENAI_API_KEY='🔑'
 ANTHROPIC_API_KEY='🔑'
 ```
 
+**Optional (AWS Bedrock):**
+
+```
+AWS_ACCESS_KEY_ID='🔑'
+AWS_SECRET_ACCESS_KEY='🔑'
+AWS_REGION='us-east-1'
+AWS_MODEL_ID='qwen.qwen3-32b-v1:0'
+# AWS_MODEL_ID='qwen.qwen3-coder-30b-a3b-v1:0'
+```
+
 **Note:**
 
 - If `ENCRYPTION_KEY` is not set, the custom API keys feature will be disabled, but the app will still work using system-level API keys.


### PR DESCRIPTION
This pull request updates the configuration and documentation to clarify and improve support for AWS Bedrock integration. The main changes include setting default AWS region and model values in the environment example file, and adding a dedicated section in the `README.md` for AWS Bedrock configuration.
solves issue :#132 

Configuration improvements:

* Set default values for `AWS_REGION` (`us-east-1`) and `AWS_MODEL_ID` (`qwen.qwen3-32b-v1:0`) in `.env.example` to provide clearer guidance for AWS Bedrock setup.

Documentation updates:

* Added an "Optional (AWS Bedrock)" section to the `README.md` with example environment variables and values for AWS Bedrock integration, making setup instructions more explicit for users.