### PR TITLE
fix: set user ID in form state and reset form on successful update

### DIFF
--- a/web/components/dashboard/settings/profile/edit-profile-form.tsx
+++ b/web/components/dashboard/settings/profile/edit-profile-form.tsx
@@ -65,6 +65,11 @@ export default function EditProfileForm(props: {
     control: form.control,
   })
   useEffect(() => {
+    if (user?.id) {
+      form.setValue("id", user.id)
+    }
+  }, [user?.id, form])
+  useEffect(() => {
     const message = formState.message
     if (!Boolean(message)) return
     if ("error" in formState) {
@@ -72,6 +77,7 @@ export default function EditProfileForm(props: {
       return
     }
     toast.success(formState.message as String)
+    form.reset(form.getValues())
     toggleEdit()
     if (formState?.newRoute) {
       router.replace(formState.newRoute)

--- a/web/lib/api/actions.ts
+++ b/web/lib/api/actions.ts
@@ -147,6 +147,7 @@ export async function updateUser(
       return { message: "Successfully updated", newRoute }
     }
     revalidatePath(`/[username]`, "page")
+    revalidatePath("/dashboard", "layout")
     return { message: "Successfully updated" }
   } catch (error) {
     if (error instanceof z.ZodError) {


### PR DESCRIPTION
## Summary
Fixes Settings form state issues after save and page refresh.

Fixes #151, #152

## Changes
- Set user ID when Clerk loads to prevent missing ID on refresh
- Reset form state after successful save to disable button correctly
- Revalidate Dashboard cache to ensure fresh data on page refresh

## Files Changed
- `web/components/dashboard/settings/profile/edit-profile-form.tsx` - Added useEffect for user ID sync and form reset
- `web/lib/api/actions.ts` - Added Dashboard revalidation after profile update

## Testing
- ✅ Save button disables after successful save
- ✅ Settings updates work after page refresh
- ✅ Form initializes with correct user data