### PR TITLE
feat: auto apply diff view on file when ai chat completes code genera…

### DIFF
--- a/web/components/project/chat/components/message.tsx
+++ b/web/components/project/chat/components/message.tsx
@@ -286,3 +286,4 @@ const MessageAction = ({
 }
 
 export { Message, MessageAction, MessageActions, MessageAvatar, MessageContent }
+

--- a/web/components/project/chat/lib/file-utils.ts
+++ b/web/components/project/chat/lib/file-utils.ts
@@ -102,5 +102,5 @@ export function extractFilesFromMessages(messages: Message[]): {
     })
   )
 
-  return { files, sourceKey: latestAssistant.content }
+  return { files, sourceKey: latestAssistant.id || latestAssistant.content }
 }

--- a/web/components/project/project-layout.tsx
+++ b/web/components/project/project-layout.tsx
@@ -278,8 +278,9 @@ export default function ProjectLayout({
     getCurrentFileContent,
     precomputeMergeForFile,
     handleApplyCodeFromChat,
-    applyPrecomputedMerge,
-    restoreOriginalFile,
+    applyPrecomputedMerge: baseApplyPrecomputedMerge,
+    restoreOriginalFile: baseRestoreOriginalFile,
+    openFile,
   } = useAIFileActions({
     projectId,
     activeTab,
@@ -290,6 +291,26 @@ export default function ProjectLayout({
     handleApplyCodeWithDecorations,
     updateFileDraft,
   })
+
+  const applyPrecomputedMerge = useCallback(
+    async (args: any) => {
+      if (baseApplyPrecomputedMerge) {
+        await baseApplyPrecomputedMerge(args)
+        forceClearAllDecorations()
+      }
+    },
+    [baseApplyPrecomputedMerge, forceClearAllDecorations]
+  )
+
+  const restoreOriginalFile = useCallback(
+    async (args: any) => {
+      if (baseRestoreOriginalFile) {
+        await baseRestoreOriginalFile(args)
+        forceClearAllDecorations()
+      }
+    },
+    [baseRestoreOriginalFile, forceClearAllDecorations]
+  )
 
   // Handler for rejecting code from chat
   const handleRejectCodeFromChat = useCallback(() => {
@@ -510,6 +531,8 @@ export default function ProjectLayout({
                 applyPrecomputedMerge={applyPrecomputedMerge}
                 restoreOriginalFile={restoreOriginalFile}
                 getCurrentFileContent={getCurrentFileContent}
+                activeFileId={activeTab?.id}
+                onOpenFile={openFile}
               />
             </ResizablePanel>
           </>

--- a/web/components/ui/markdown.tsx
+++ b/web/components/ui/markdown.tsx
@@ -11,7 +11,6 @@ import {
 import { BundledLanguage } from "shiki"
 import { Streamdown } from "streamdown"
 import { CodeBlock, CodeBlockCopyButton } from "./code-block"
-import { CodeBlockActions } from "./code-block-actions"
 type MarkdownProps = ComponentProps<typeof Streamdown>
 
 export const Markdown = memo(
@@ -102,13 +101,6 @@ export const Markdown = memo(
                 isNewFile={fileIsNew}
                 showToolbar
               >
-                {/* Toolbar actions (Apply, Reject, Copy) */}
-                <CodeBlockActions
-                  code={code}
-                  language={language}
-                  intendedFile={intendedFile}
-                  placement="toolbar"
-                />
                 <CodeBlockCopyButton className="size-7" />
               </CodeBlock>
             )


### PR DESCRIPTION
# feat: Auto-apply diff view on AI code generation

## Summary
This PR introduces a feature that automatically displays the visual diff in the editor as soon as the AI finishes generating code for a file. It mimics the behavior of IDEs like Cursor or Windsurf, providing immediate visual feedback. It also handles auto-opening files if they are not currently active and cleans up the UI by removing redundant buttons.

## Key Changes

### Auto-Diff Trigger: 
The editor now automatically switches to the diff view when a file's merge status becomes "ready".
Auto-Open File: If the generated file is not currently open or active, the system automatically opens it and switches to it before showing the diff.

### UI Cleanup: 
Removed the "Accept" and "Reject" buttons from the chat code blocks, as the auto-diff view and the file preview list provide this functionality.
Decoration Management: Implemented logic to explicitly clear diff decorations (green/red highlights) when "Keep" or "Reject" is clicked.

### Issue:
Closes #202 
