### PR TITLE
Fix: Enable Multiple File Attachments in AI Chat

### DIFF
--- a/web/components/project/chat/providers/chat-provider.tsx
+++ b/web/components/project/chat/providers/chat-provider.tsx
@@ -119,15 +119,29 @@ function ChatProvider({
 
   const addContextTab = useCallback((newTab: ContextTab) => {
     setContextTabs((prev) => {
-      // Check for duplicate by type and content
+      // Check for duplicate by id
+      if (prev.some((tab) => tab.id === newTab.id)) {
+        return prev
+      }
+
+      // Check for duplicate by type and name/content
       const isDuplicate = prev.some((tab) => {
         if (tab.type !== newTab.type) return false
-        if (tab.type === "file" || tab.type === "image") {
+
+        // For files, images, and code (file context), check by name
+        if (
+          tab.type === "file" ||
+          tab.type === "image" ||
+          tab.type === "code"
+        ) {
           return tab.name === newTab.name
         }
-        if (tab.content === newTab.content) {
-          return true
+
+        // For text snippets, check by content
+        if (tab.type === "text" && tab.content && newTab.content) {
+          return tab.content === newTab.content
         }
+
         return false
       })
 


### PR DESCRIPTION
This PR resolves an issue where users were restricted to attaching only a single file at a time in the AI chat input. Additionally, it fixes a bug in the duplicate detection logic that caused false "Snippet already added" errors when adding multiple code files.

### Changes

`components/project/chat/providers/chat-provider.tsx`:

Refined the addContextTab duplicate detection logic.
It now prioritizes checking by id and name for `file/image/code ` types.
Content comparison is now restricted to text snippets only. This prevents undefined content in new code tabs from being incorrectly flagged as duplicates.

### Issue
Closes #206 